### PR TITLE
mbed-cloud-client: drop glibc dependency

### DIFF
--- a/recipes-connectivity/mbed-cloud-client/mbed-cloud-client_git.bb
+++ b/recipes-connectivity/mbed-cloud-client/mbed-cloud-client_git.bb
@@ -24,7 +24,6 @@ DEPENDS += "\
     ${PYTHON_PN}-native \
     ${PYTHON_PN}-pip-native \
     ${PYTHON_PN}-mbed-cli-native \
-    glibc \
 "
 
 RDEPENDS_${PN} = " \


### PR DESCRIPTION
No need to explicitly depend on glibc, as dependency is already part of
the build and forcing glibc makes it incompatible with musl.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>