### PR TITLE
mbed-cloud-client: bring in upstream cmake class changes

### DIFF
--- a/recipes-connectivity/mbed-cloud-client/mbed-cloud-client_git.bb
+++ b/recipes-connectivity/mbed-cloud-client/mbed-cloud-client_git.bb
@@ -61,8 +61,8 @@ cmake_do_generate_toolchain_file() {
 # CMake system name must be something like "Linux".
 # This is important for cross-compiling.
 $cmake_crosscompiling
-set( CMAKE_SYSTEM_NAME `echo ${TARGET_OS} | sed -e 's/^./\u&/' -e 's/^\(Linux\).*/\1/'` )
-set( CMAKE_SYSTEM_PROCESSOR ${@map_target_arch_to_uname_arch(d.getVar('TARGET_ARCH'))} )
+set( CMAKE_SYSTEM_NAME ${@map_host_os_to_system_name(d.getVar('HOST_OS'))} )
+set( CMAKE_SYSTEM_PROCESSOR ${@map_host_arch_to_uname_arch(d.getVar('HOST_ARCH'))} )
 set( CMAKE_C_COMPILER ${OECMAKE_EXTRA_ROOT_PATH}/${OECMAKE_C_COMPILER} )
 set( CMAKE_CXX_COMPILER ${OECMAKE_EXTRA_ROOT_PATH}/${OECMAKE_CXX_COMPILER} )
 set( CMAKE_C_COMPILER_LAUNCHER ${OECMAKE_C_COMPILER_LAUNCHER} )


### PR DESCRIPTION
Upstream commit
https://github.com/openembedded/openembedded-core/commit/01245db2893e39ffb5d4a00e4689f048d0698974
changed part of cmake_do_generate_toolchain_file() to fix HOST detection.

We need to mirror that change in the mbed-cloud-client recipe to fix the
build.

NOTE: The idea of overriding these cmake class functions / settings is a
really ugly hack and needs to be fixed in a future commit.

Signed-off-by: Michael Scott <mike@foundries.io>